### PR TITLE
Update robustbase.py

### DIFF
--- a/src/robustbase.py
+++ b/src/robustbase.py
@@ -120,9 +120,8 @@ def Qn(x, constant = 2.21914, finite_corr=True):
     h=0
     k=0
     for i in range(0,n):
-        for j in range(0,n):
-            if i<j:
-                diff.append(abs(x[i]-x[j]))
+        for j in range(i + 1,n):
+            diff.append(abs(x[i]-x[j]))
 
     diff.sort()
     h=int(math.floor(n/2)+1)


### PR DESCRIPTION
In line 123, setting a j-range from i +1 to n enhances performance a lot since then there is no need to check if j is greater than i or not. Especially for large data sets, where this check will mostly be negative a lot of checks can be omitted.